### PR TITLE
Winner selection

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -96,3 +96,7 @@
   position: absolute;
   top: 0; left: 0;
 }
+
+.winner {
+  background-color: #b1c8d4;
+}

--- a/app/controllers/dare_submissions_controller.rb
+++ b/app/controllers/dare_submissions_controller.rb
@@ -4,8 +4,10 @@ class DareSubmissionsController < ApplicationController
   
   def create
     @dare_submission = current_user.dare_submissions.build(dare_submission_params)
-    
-    if @dare_submission.save
+    if @dare_submission.valid? && !@dare_submission.dare.winning_submission_id.nil?
+      flash[:danger] = "Submissions are Closed! Submission not created!"
+      redirect_to dare_path(@dare_submission.dare.id)
+    elsif @dare_submission.save
       flash[:success] = "Dare Submission created!"
       redirect_to dare_path(@dare_submission.dare.id)
     else
@@ -29,7 +31,11 @@ class DareSubmissionsController < ApplicationController
   end
   
   def new
-    if (!Dare.find_by(id: dare_submission_params[:dare_id]).nil? )
+    dare = Dare.find_by(id: dare_submission_params[:dare_id])
+    if (!dare.nil? && !dare.winning_submission_id.nil?)
+      flash[:danger] = "Submissions are Closed! Submission not created!"
+      redirect_to dare_path(dare.id)
+    elsif (!dare.nil? )
       @dare_submission = current_user.dare_submissions.build(dare_submission_params)
     else
       flash[:danger] = "Cannot Submit to Nonexistent Dare"
@@ -41,13 +47,31 @@ class DareSubmissionsController < ApplicationController
     @dare = Dare.find_by(id: dare_submission_params[:dare_id])
     @dare_submission = DareSubmission.find_by(id: params[:dare_submission][:id])
     @dare_submission_user = @dare_submission.user
-    if user_signed_in? && current_user.id == @dare.user_id
-      @dare_submission_user.karma_points = @dare_submission_user.karma_points + @dare.karma_offer
-      if @dare_submission_user.save
-        flash[:success] = "Karma rewarded!"
+    if user_signed_in? && current_user.id == @dare.user_id && @dare.winning_submission_id.nil?
+      begin
+        DareSubmission.transaction do
+          @dare_submission_user.karma_points = @dare_submission_user.karma_points + @dare.karma_offer
+          @dare.winning_submission_id = @dare_submission.id
+          @dare.save!
+          @dare_submission_user.save!
+          flash[:success] = "Karma rewarded!"
+        end
+        rescue => exception
+          flash[:danger] = "Failed to perform transaction: #{exception}"
       end
-      redirect_to dare_path(@dare.id)
+      
+      # @dare_submission_user.karma_points = @dare_submission_user.karma_points + @dare.karma_offer
+      # if @dare_submission_user.save
+      #   flash[:success] = "Karma rewarded!"
+      # else
+      #   redirect_to dare_path(@dare.id)
+      # end
+    else
+      flash[:danger] = "No Karma awarded!"
     end
+    redirect_to dare_path(@dare.id)
+     
+    
   end
   
   private
@@ -63,6 +87,7 @@ class DareSubmissionsController < ApplicationController
       @dare_submission = current_user.dare_submissions.find_by(id: params[:id])
       redirect_to root_url if @dare_submission.nil?
     end
+    
 
     def dare_submission_params
       params.require(:dare_submission).permit(:content, :description, :dare_id)

--- a/app/models/dare.rb
+++ b/app/models/dare.rb
@@ -11,6 +11,10 @@ class Dare < ApplicationRecord
   
   after_create :transfer_points
 
+  def winner_selected
+    return !self.winning_submission_id.nil?
+  end
+  
   
   def add_karma(points)
     self.karma_offer += points

--- a/app/models/dare_submission.rb
+++ b/app/models/dare_submission.rb
@@ -9,4 +9,7 @@ class DareSubmission < ApplicationRecord
                       format: { with: VALID_YOUTUBE_REGEX }
   validates :description, presence: true
   
+  
+  
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,12 +13,12 @@ class User < ApplicationRecord
          
   def add_karma(points)
     self.karma_points += points
-    self.save
+    self.save!
   end
   
   def remove_karma(points)
     self.karma_points -= points
-    self.save
+    self.save!
   end
          
   

--- a/app/views/dare_submissions/_dare_submissions.html.erb
+++ b/app/views/dare_submissions/_dare_submissions.html.erb
@@ -1,5 +1,5 @@
 <% dare_submissions.each do |dare_submission| %>
-  <div id="dare_submission-<%= dare_submission.id %>" class="dare-submission-box">
+  <div id="dare_submission-<%= dare_submission.id %>" class="dare-submission-box <% if (dare_submission.id == dare_submission.dare.winning_submission_id) %>winner<% end %>">
     <div class="row">
       <div class="col-md-4"> 
         <%= embed(dare_submission.content) %>
@@ -24,11 +24,15 @@
                                       submission_like: { dare_submission_id: dare_submission.id } }, 
                                     {class: 'btn btn-primary btn-sm', method: :post }) %>
         </span>
-        <% if (current_user == dare_submission.dare.user) %>
+        <% if (current_user == dare_submission.dare.user && !dare_submission.dare.winner_selected) %>
             <%= link_to("Reward karma!", { controller: "dare_submissions", action: "transfer_karma", 
                                       dare_submission: { id: dare_submission.id, dare_id: dare_submission.dare_id }}, 
                                     {class: 'btn btn-primary btn-sm', method: :post }) %>
         <% end %>
+        
+        <% if (dare_submission.id == dare_submission.dare.winning_submission_id) %>WINNER<% end %>
+                                    
+
       </div>
     </div>
   </div>

--- a/db/migrate/20161115021502_add_dare_winner_id_to_dare.rb
+++ b/db/migrate/20161115021502_add_dare_winner_id_to_dare.rb
@@ -1,0 +1,6 @@
+class AddDareWinnerIdToDare < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :dares, :winning_submission
+    add_foreign_key :dares, :dare_submissions, column: :winning_submission
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161104065007) do
+ActiveRecord::Schema.define(version: 20161115021502) do
 
   create_table "comment_likes", force: :cascade do |t|
     t.integer  "user_id"
@@ -46,11 +46,13 @@ ActiveRecord::Schema.define(version: 20161104065007) do
     t.string   "title"
     t.text     "description"
     t.integer  "user_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
     t.integer  "karma_offer"
+    t.integer  "winning_submission_id"
     t.index ["user_id", "created_at"], name: "index_dares_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_dares_on_user_id"
+    t.index ["winning_submission_id"], name: "index_dares_on_winning_submission_id"
   end
 
   create_table "submission_likes", force: :cascade do |t|

--- a/spec/controllers/dare_submissions_controller_spec.rb
+++ b/spec/controllers/dare_submissions_controller_spec.rb
@@ -286,8 +286,41 @@ RSpec.describe DareSubmissionsController, type: :controller do
             }
           assert_equal @dare_submission.user.karma_points + @dare.karma_offer, @user2.reload.karma_points
         end
-      
       end
+      
+      context "incorrect user signed in" do
+        before do
+          sign_in @user2
+        end
+        it 'redirects with danger flash' do
+          post :transfer_karma,
+            params: {
+              dare_submission:{id: @dare_submission.id, dare_id: @dare.id}
+            }
+            expect(response).to redirect_to dare_path(@dare.id)
+            assert_equal flash.empty?, false
+            expect(flash[:danger]).to match("No Karma awarded!")
+        end
+        
+        it 'doe not update dare.winning_submission_id' do
+          assert_equal nil, @dare.winning_submission_id
+          post :transfer_karma,
+            params: {
+              dare_submission:{id: @dare_submission.id, dare_id: @dare.id}
+            }
+          assert_equal nil, @dare.reload.winning_submission_id
+        end
+        
+        it 'user of dare_submission karma points do not change' do
+          post :transfer_karma,
+            params: {
+              dare_submission:{id: @dare_submission.id, dare_id: @dare.id}
+            }
+          assert_equal @dare_submission.user.karma_points, @user2.reload.karma_points
+        end
+      end
+      
+      
     end
     
     context 'winner selected already' do

--- a/spec/controllers/dares_controller_spec.rb
+++ b/spec/controllers/dares_controller_spec.rb
@@ -69,7 +69,6 @@ describe DaresController do
         end
         
         it "renders the index method" do
-          get :new
           post :create,
             params: { dare: FactoryGirl.attributes_for(:dare) }
           expect(response).to redirect_to show_dare_list_path
@@ -201,10 +200,9 @@ describe DaresController do
         assert_select 'h3', "No Dares Posted Yet"
       end
     end
-    
-   
-    
-    
-    
   end
+  
+  
+  
+  
 end


### PR DESCRIPTION
Made it so karma is transferred to the winner of the selected post
- updated dare page to remove buttons to create more dare submissions or select more winners
- made it so more dare submissions or winner selections cannot be made after winner is already selected
- updated model for dare to have winning_submission_id, starts off as nil to indicate there is no winner yet
- add tests to verify this